### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "bignumber.js": "^9.0.0",
     "compression": "^1.7.4",
     "express": "^4.17.1",
-    "npm": "^6.7.0",
     "truffle-hdwallet-provider": "1.0.2",
     "vue": "^2.5.2",
     "vue-progressbar": "^0.7.5",


### PR DESCRIPTION

Hello pigfarmteam!

It seems like you have npm as one of your (dev-) dependency in gomoku.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
